### PR TITLE
Tag errored torrents

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,19 @@ You can view the logs under `~/scripts/qbit-race/logs` to try and debug.
 
 These are additional parameters you can specify in autoDL for additional functionality
 
+## Other Scripts
+
+### Tag Errored Torrents
+
+Sometimes torrents may be deleted from the tracker, or just an error in general. qBittorrent provides no easy way of sorting by these errors (Usually tracker responds with an error message).
+
+To tag all such torrents as `error`, from the root folder (`~/qbit-race`), run:
+```
+npm run tag_unreg
+```
+
+This will tag all torrents which do not have ANY working tracker.
+
 ### Torrent Category
 
 In the arguments field, you may specify a category (per filter, or global) by adding to the end of arguments `--category "the category name"`

--- a/bin/tag_errored.js
+++ b/bin/tag_errored.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+//Create logs folder if it doesnt exist
+const logsDir = path.join(__dirname, '../logs');
+if (!fs.existsSync(logsDir) || !fs.lstatSync(logsDir).isDirectory()){
+    fs.mkdirSync(logsDir);
+}
+
+const { setLogfile } = require('../build/config');
+setLogfile('tag_errored.log');
+const { tagErroredTorrents } = require('../build/tag_error');
+const args = process.argv.slice(2);
+tagErroredTorrents(args);

--- a/build/qbittorrent/api.js
+++ b/build/qbittorrent/api.js
@@ -125,11 +125,11 @@ exports.addTags = (torrents, tags) => {
                 'Content-Type': 'application/x-www-form-urlencoded'
             }
         }).then(response => {
-            logger_1.feedLogger.log('ADD TAGS', `Successfully added ${tags.length} tags to ${torrents.length} torrents.`);
+            logger_1.feedLogger.log('ADD TAGS API', `Successfully added ${tags.length} tags to ${torrents.length} torrents.`);
             resolve();
         }).catch(error => {
             // console.log(error.response);
-            logger_1.feedLogger.log('ADD TAGS', `Failed with error code ${error.response.status}`);
+            logger_1.feedLogger.log('ADD TAGS API', `Failed with error code ${error.response.status}`);
         });
     });
 };

--- a/build/tag_error.js
+++ b/build/tag_error.js
@@ -1,0 +1,69 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.tagErroredTorrents = void 0;
+const auth_1 = require("./qbittorrent/auth");
+const api_1 = require("./qbittorrent/api");
+const logger_1 = require("./helpers/logger");
+/**
+ * tagErroredTorrents gets a list of torrents from qBit, and then traverses their tracker.
+ * If for any of them, apart from DHT, PEX etc. not a single tracker is status 2 (working)
+ * It will tag them as an errored torrent
+ * Requested by Xan
+ */
+exports.tagErroredTorrents = async (args) => {
+    const dryRun = args.some(arg => arg === '--dry-run');
+    if (dryRun === true) {
+        logger_1.feedLogger.log('FLAGS', `--dry-run specified. Will not tag any torrents!`);
+    }
+    let torrents;
+    let t1 = Date.now();
+    try {
+        await auth_1.login();
+    }
+    catch (error) {
+        logger_1.feedLogger.log('AUTH', 'Failed to login to qBittorrent');
+        process.exit(1);
+    }
+    //We logged in. Get the torrents
+    try {
+        torrents = await api_1.getTorrents();
+    }
+    catch (error) {
+        logger_1.feedLogger.log('GET TORRENTS', 'Failed to get torrents from qBittorrent');
+        process.exit(1);
+    }
+    //Map it to the useful shit, aka just infohashes (and name maybe).
+    //This is actually pointless but map looks cool so yolo. It may even free some memory
+    //When the GC runs
+    torrents = torrents.map(({ name, hash }) => ({ name, hash }));
+    let toTag = [];
+    //Loop over them 
+    for (const torrent of torrents) {
+        let trackers = await api_1.getTrackers(torrent.hash);
+        trackers.splice(0, 3);
+        let working = trackers.some(tracker => tracker.status === 2);
+        if (!working) {
+            logger_1.feedLogger.log('CHECK', `[${torrent.hash}] tracker error for ${torrent.name}`);
+            toTag.push(torrent);
+        }
+    }
+    //Now let's tag them
+    if (toTag.length === 0) {
+        logger_1.feedLogger.log('TAG', 'No errored torrents to tag...');
+        process.exit(0);
+    }
+    if (dryRun === true) {
+        logger_1.feedLogger.log('TAG', 'Finished Dry Run. Exiting...');
+        return;
+    }
+    logger_1.feedLogger.log('TAG', `Tagging ${toTag.length} torrents...`);
+    try {
+        await api_1.addTags(toTag, ['error']);
+    }
+    catch (error) {
+        logger_1.feedLogger.log('TAG', 'Failed to set tags');
+        process.exit(1);
+    }
+    logger_1.feedLogger.log('TAG', `Successfully tagged ${toTag.length} torrents!`);
+};
+//# sourceMappingURL=tag_error.js.map

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "nodemon src/index.ts",
     "start": "node build/index.js",
     "validate": "node tests/validate.js",
+    "tag_unreg": "node bin/tag_errored.js",
     "test-dev": "ts-node src/index.ts"
   },
   "author": "Raghu Saxena",

--- a/src/qbittorrent/api.ts
+++ b/src/qbittorrent/api.ts
@@ -138,11 +138,11 @@ export const addTags = (torrents: any[], tags: string[]) => {
                 'Content-Type': 'application/x-www-form-urlencoded'
             }
         }).then(response => {
-            feedLogger.log('ADD TAGS', `Successfully added ${tags.length} tags to ${torrents.length} torrents.`);
+            feedLogger.log('ADD TAGS API', `Successfully added ${tags.length} tags to ${torrents.length} torrents.`);
             resolve();
         }).catch(error => {
             // console.log(error.response);
-            feedLogger.log('ADD TAGS', `Failed with error code ${error.response.status}`);
+            feedLogger.log('ADD TAGS API', `Failed with error code ${error.response.status}`);
         });
     });
 }

--- a/src/tag_error.ts
+++ b/src/tag_error.ts
@@ -1,0 +1,78 @@
+import { login } from './qbittorrent/auth';
+import { addTags, getTorrents, getTrackers } from './qbittorrent/api';
+import { feedLogger } from './helpers/logger';
+
+/**
+ * tagErroredTorrents gets a list of torrents from qBit, and then traverses their tracker.
+ * If for any of them, apart from DHT, PEX etc. not a single tracker is status 2 (working)
+ * It will tag them as an errored torrent
+ * Requested by Xan
+ */
+
+ export const tagErroredTorrents = async (args: string[]) => {
+
+    const dryRun = args.some(arg => arg === '--dry-run');
+
+    if (dryRun === true){
+        feedLogger.log('FLAGS', `--dry-run specified. Will not tag any torrents!`);
+    }
+
+    let torrents: any[];
+    let t1 = Date.now();
+
+    try {
+        await login();
+    } catch (error){
+        feedLogger.log('AUTH', 'Failed to login to qBittorrent');
+        process.exit(1);
+    }
+
+    //We logged in. Get the torrents
+
+    try {
+        torrents = await getTorrents();
+    } catch (error){
+        feedLogger.log('GET TORRENTS', 'Failed to get torrents from qBittorrent');
+        process.exit(1);
+    }
+
+    //Map it to the useful shit, aka just infohashes (and name maybe).
+    //This is actually pointless but map looks cool so yolo. It may even free some memory
+    //When the GC runs
+    torrents = torrents.map(({ name, hash }) => ({ name, hash }));
+    let toTag: string[] = [];
+    //Loop over them 
+    for (const torrent of torrents){
+        
+        let trackers: any[] = await getTrackers(torrent.hash);
+        trackers.splice(0, 3);
+        let working = trackers.some(tracker => tracker.status === 2);
+
+        if (!working){
+            feedLogger.log('CHECK', `[${torrent.hash}] tracker error for ${torrent.name}`);
+            toTag.push(torrent);
+        }
+    }
+
+    //Now let's tag them
+    if (toTag.length === 0){
+        feedLogger.log('TAG', 'No errored torrents to tag...');
+        process.exit(0);
+    }
+
+    if (dryRun === true){
+        feedLogger.log('TAG', 'Finished Dry Run. Exiting...');
+        return;
+    }
+
+    feedLogger.log('TAG', `Tagging ${toTag.length} torrents...`);
+
+    try {
+        await addTags(toTag, ['error']);
+    } catch (error){
+        feedLogger.log('TAG', 'Failed to set tags');
+        process.exit(1);
+    }
+
+    feedLogger.log('TAG', `Successfully tagged ${toTag.length} torrents!`);
+ }


### PR DESCRIPTION
Fixes https://github.com/ckcr4lyf/qbit-race/issues/1

Note: It was chosen to tag them by default, and not have delete, delete with data options. 
Once tagged, it is trivial to do so from the Web UI, and offending torrents can also be visually checked once.