### PR TITLE
Differentiate between qbit api error & invalid credentials

### DIFF
--- a/build/src/qbittorrent/auth.js
+++ b/build/src/qbittorrent/auth.js
@@ -3,9 +3,17 @@ import { login as apiLogin, QbittorrentApi } from './api.js';
 export const loginV2 = async (qbittorrentSettings) => {
     const logger = getLoggerV3();
     const response = await apiLogin(qbittorrentSettings);
-    // TODO: Differentiate between wrong credentials vs. qbit is not listening (wrong URL / port etc.)
+    if (response.status != 200) {
+        logger.error(`Unknown error logging in!\nStatus: ${response.status}\nHeaders: ${response.headers}\nBody: ${response.data}`);
+        throw new Error("Failed to authenticate (UNKNOWN ERROR)");
+    }
+    if (response.data === 'Fails.') {
+        logger.warn(`Incorrect credentials!`);
+        throw new Error("Incorrect credentials");
+    }
     if (response.headers['set-cookie'] === undefined || Array.isArray(response.headers['set-cookie']) === false || response.headers['set-cookie'].length === 0) {
-        throw new Error(`Failed to authenticate`);
+        logger.error(`Missing set cookie header from response!\nStatus: ${response.status}\nHeaders: ${response.headers}\nBody: ${response.data}`);
+        throw new Error(`Failed to authenticate (UNKNOWN ERROR)`);
     }
     return new QbittorrentApi(qbittorrentSettings.url, response.headers['set-cookie'][0]);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qbit-race",
-  "version": "2.0.0-alpha.6",
+  "version": "2.0.0-alpha.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "qbit-race",
-      "version": "2.0.0-alpha.6",
+      "version": "2.0.0-alpha.9",
       "license": "ISC",
       "dependencies": {
         "@ckcr4lyf/bencode-esm": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qbit-race",
-  "version": "2.0.0-alpha.8",
+  "version": "2.0.0-alpha.9",
   "description": "Qbit utilities for racing",
   "main": "./bin/index.js",
   "type": "module",

--- a/src/qbittorrent/auth.ts
+++ b/src/qbittorrent/auth.ts
@@ -6,12 +6,21 @@ import { login as apiLogin, QbittorrentApi } from './api.js';
 
 export const loginV2 = async (qbittorrentSettings: QBITTORRENT_SETTINGS): Promise<QbittorrentApi> => {
     const logger = getLoggerV3();
-
     const response = await apiLogin(qbittorrentSettings);
 
-    // TODO: Differentiate between wrong credentials vs. qbit is not listening (wrong URL / port etc.)
+    if (response.status != 200){
+        logger.error(`Unknown error logging in!\nStatus: ${response.status}\nHeaders: ${response.headers}\nBody: ${response.data}`)
+        throw new Error("Failed to authenticate (UNKNOWN ERROR)");
+    }
+
+    if (response.data === 'Fails.'){
+        logger.warn(`Incorrect credentials!`);
+        throw new Error("Incorrect credentials");
+    }
+
     if (response.headers['set-cookie'] === undefined || Array.isArray(response.headers['set-cookie']) === false || response.headers['set-cookie'].length === 0) {
-        throw new Error(`Failed to authenticate`);
+        logger.error(`Missing set cookie header from response!\nStatus: ${response.status}\nHeaders: ${response.headers}\nBody: ${response.data}`);
+        throw new Error(`Failed to authenticate (UNKNOWN ERROR)`);
     }
 
     return new QbittorrentApi(qbittorrentSettings.url, response.headers['set-cookie'][0]);


### PR DESCRIPTION
The response for wrong credz is HTTP 200 w/ body = `Fails.` 

Anything else we consider UNKNOWN ERROR.