### PR TITLE
Race existing torrent via infohash

### DIFF
--- a/bin/index.mjs
+++ b/bin/index.mjs
@@ -64,8 +64,10 @@ program.command('add').description('Add a new torrent').requiredOption('-p, --pa
     await addTorrentToRace(api, config, options.path, options.category);
 })
 
-// TODO: Add command `race` , takes in an infohash and treats it as if just added
-// Usecase: If torrent is added via another program (e.g. sonarr / radarr)
+program.command('race').description('Race an existing torrent').requiredOption('-i, --infohash <infohash>', 'The infohash of the torrent already in qBittorrent. Not case sensitive').action(async(options) => {
+    logger.debug(`Called with infohash ${options.infohash}`);    
+    // TODO: New command to race existing infohash
+})
 
 program.command('metrics').description('Start a prometheus metrics server').action(async () => {
     const api = await loginV2(config.QBITTORRENT_SETTINGS);

--- a/bin/index.mjs
+++ b/bin/index.mjs
@@ -8,6 +8,7 @@ import { buildTorrentAddedBody } from '../build/src/discord/messages.js'
 import { getLoggerV3 } from '../build/src/utils/logger.js'
 import { tagErroredTorrents } from '../build/src/racing/tag.js'
 import { postRaceResumeV2 } from '../build/src/racing/completed.js'
+import { raceExisting } from '../build/src/racing/common.js'
 import { startMetricsServer } from '../build/src/server/appFactory.js';
 import { addTorrentToRace } from '../build/src/racing/add.js';
 
@@ -65,8 +66,15 @@ program.command('add').description('Add a new torrent').requiredOption('-p, --pa
 })
 
 program.command('race').description('Race an existing torrent').requiredOption('-i, --infohash <infohash>', 'The infohash of the torrent already in qBittorrent. Not case sensitive').action(async(options) => {
-    logger.debug(`Called with infohash ${options.infohash}`);    
-    // TODO: New command to race existing infohash
+    logger.debug(`Going to race ${options.infohash}`);
+    logger.info(`Going to login`);
+    const api = await loginV2(config.QBITTORRENT_SETTINGS);
+
+    try {
+        await raceExisting(api, config, options.infohash);
+    } catch (e){
+        logger.error(`Failed to race ${options.infohash}. Error: ${e}. (${e.stack})`);
+    }
 })
 
 program.command('metrics').description('Start a prometheus metrics server').action(async () => {

--- a/bin/index.mjs
+++ b/bin/index.mjs
@@ -64,6 +64,9 @@ program.command('add').description('Add a new torrent').requiredOption('-p, --pa
     await addTorrentToRace(api, config, options.path, options.category);
 })
 
+// TODO: Add command `race` , takes in an infohash and treats it as if just added
+// Usecase: If torrent is added via another program (e.g. sonarr / radarr)
+
 program.command('metrics').description('Start a prometheus metrics server').action(async () => {
     const api = await loginV2(config.QBITTORRENT_SETTINGS);
     startMetricsServer(config, api);

--- a/build/src/discord/messages.js
+++ b/build/src/discord/messages.js
@@ -37,6 +37,37 @@ export const buildTorrentAddedBody = (discordSettings, torrentAddedInfo) => {
     };
     return buildMessageBody(discordSettings, partialBody);
 };
+// TODO: generalize with above
+export const buildRacingBody = (discordSettings, torrentAddedInfo) => {
+    const humanSize = humanFileSize(torrentAddedInfo.size, false, 2);
+    let partialBody = {
+        content: `Added ${torrentAddedInfo.name} (${humanSize})`,
+        embeds: [
+            {
+                title: torrentAddedInfo.name,
+                description: 'Racing in qBittorrent',
+                thumbnail: {
+                    url: discordSettings.botAvatar,
+                },
+                fields: [
+                    {
+                        name: torrentAddedInfo.trackers.length === 1 ? 'Tracker' : 'Trackers',
+                        value: torrentAddedInfo.trackers.join('\n')
+                    },
+                    {
+                        name: 'Size',
+                        value: humanSize
+                    },
+                    {
+                        name: 'Reannounce Count',
+                        value: torrentAddedInfo.reannounceCount.toString()
+                    }
+                ]
+            }
+        ]
+    };
+    return buildMessageBody(discordSettings, partialBody);
+};
 export const buildTorrentCompletedBody = (discordSettings, torrent) => {
     const humanSize = humanFileSize(torrent.size, false, 2);
     let partialBody = {

--- a/build/src/qbittorrent/api.js
+++ b/build/src/qbittorrent/api.js
@@ -56,11 +56,16 @@ export class QbittorrentApi {
         }
         const infohashes = torrents.map(torrent => torrent.hash);
         const payload = `hashes=${infohashes.join('|')}&tags=${tags.join(',')}`;
-        await this.client.post(ApiEndpoints.addTags, payload, {
-            headers: {
-                'Content-Type': 'application/x-www-form-urlencoded',
-            }
-        });
+        try {
+            await this.client.post(ApiEndpoints.addTags, payload, {
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                }
+            });
+        }
+        catch (e) {
+            throw new Error(`Failed to add tags to torrent: ${e}`);
+        }
     }
     async setCategory(infohash, category) {
         const payload = `hashes=${infohash}&category=${category}`;

--- a/build/src/qbittorrent/api.js
+++ b/build/src/qbittorrent/api.js
@@ -25,6 +25,7 @@ export class QbittorrentApi {
     async getTorrent(infohash) {
         try {
             const torrents = await this.getTorrents([infohash]);
+            console.log(torrents);
             return torrents[0];
         }
         catch (e) {
@@ -83,9 +84,10 @@ export class QbittorrentApi {
         if (torrents.length === 0) {
             return;
         }
-        await this.client.get(ApiEndpoints.pauseTorrents, {
-            params: {
-                hashes: torrents.map(torrent => torrent.hash).join('|')
+        const payload = `hashes=${torrents.map(torrent => torrent.hash).join('|')}`;
+        await this.client.post(ApiEndpoints.pauseTorrents, payload, {
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
             }
         });
     }

--- a/build/src/qbittorrent/api.js
+++ b/build/src/qbittorrent/api.js
@@ -16,21 +16,23 @@ export class QbittorrentApi {
         if (Array.isArray(hashes)) {
             params.hashes = hashes.join('|');
         }
-        const response = await this.client.get(ApiEndpoints.torrentsInfo, {
-            params: params,
-        });
-        return response.data;
-    }
-    // Just wraps getTorrents as a convenience method for single torrent
-    async getTorrent(infohash) {
         try {
-            const torrents = await this.getTorrents([infohash]);
-            console.log(torrents);
-            return torrents[0];
+            const response = await this.client.get(ApiEndpoints.torrentsInfo, {
+                params: params,
+            });
+            return response.data;
         }
         catch (e) {
             throw new Error(`Failed to get torrents from qBittorrent API. Error: ${e}`);
         }
+    }
+    // Just wraps getTorrents as a convenience method for single torrent
+    async getTorrent(infohash) {
+        const torrents = await this.getTorrents([infohash]);
+        if (torrents.length === 0) {
+            throw new Error(`Torrent not found! (Infohash = ${infohash})`);
+        }
+        return torrents[0];
     }
     async getTrackers(infohash) {
         try {

--- a/build/src/qbittorrent/api.js
+++ b/build/src/qbittorrent/api.js
@@ -124,11 +124,17 @@ export class QbittorrentApi {
         });
     }
     async reannounce(infohash) {
-        await this.client.get(ApiEndpoints.reannounce, {
-            params: {
-                hashes: infohash,
-            }
-        });
+        const payload = `hashes=${infohash}`;
+        try {
+            await this.client.post(ApiEndpoints.reannounce, payload, {
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                }
+            });
+        }
+        catch (e) {
+            throw new Error(`Failed to reannounce! Error: ${e}`);
+        }
     }
     async getTransferInfo() {
         const response = await this.client.get(ApiEndpoints.transferInfo);

--- a/build/src/qbittorrent/api.js
+++ b/build/src/qbittorrent/api.js
@@ -23,16 +23,26 @@ export class QbittorrentApi {
     }
     // Just wraps getTorrents as a convenience method for single torrent
     async getTorrent(infohash) {
-        const torrents = await this.getTorrents([infohash]);
-        return torrents[0];
+        try {
+            const torrents = await this.getTorrents([infohash]);
+            return torrents[0];
+        }
+        catch (e) {
+            throw new Error(`Failed to get torrents from qBittorrent API. Error: ${e}`);
+        }
     }
     async getTrackers(infohash) {
-        const response = await this.client.get(ApiEndpoints.torrentTrackers, {
-            params: {
-                hash: infohash,
-            }
-        });
-        return response.data;
+        try {
+            const response = await this.client.get(ApiEndpoints.torrentTrackers, {
+                params: {
+                    hash: infohash,
+                }
+            });
+            return response.data;
+        }
+        catch (e) {
+            throw new Error(`Failed to get trackers from qBittorrent API for ${infohash}. Error: ${e}`);
+        }
     }
     async addTags(torrents, tags) {
         if (torrents.length === 0) {
@@ -58,11 +68,16 @@ export class QbittorrentApi {
         });
     }
     async resumeTorrents(torrents) {
-        await this.client.get(ApiEndpoints.resumeTorrents, {
-            params: {
-                hashes: torrents.map(torrent => torrent.hash).join('|'),
-            }
-        });
+        try {
+            await this.client.get(ApiEndpoints.resumeTorrents, {
+                params: {
+                    hashes: torrents.map(torrent => torrent.hash).join('|'),
+                }
+            });
+        }
+        catch (e) {
+            throw new Error(`Failed to resume torrents. Error: ${e}`);
+        }
     }
     async pauseTorrents(torrents) {
         if (torrents.length === 0) {

--- a/build/src/racing/add.js
+++ b/build/src/racing/add.js
@@ -43,6 +43,7 @@ export const addTorrentToRace = async (api, settings, path, category) => {
         logger.info(`Pre race conditions not met. Skipping ${torrentMetainfo.name}`);
         process.exit(0);
     }
+    // TODO: Move to common race part
     const torrentsToPause = getTorrentsToPause(settings, torrents);
     try {
         logger.debug(`Going to pause ${torrentsToPause.length} torrents for the race...`);

--- a/build/src/racing/common.js
+++ b/build/src/racing/common.js
@@ -69,6 +69,7 @@ export const raceExisting = async (api, settings, infohash) => {
     }
     // TODO: Add trackers as tags?
     const torrent = await api.getTorrent(infohash);
+    console.log(torrent);
     const announceOk = await reannounce(api, settings, torrent);
     if (announceOk === false) {
         logger.debug(`Going to resume torrents since failed to race`);

--- a/build/src/racing/common.js
+++ b/build/src/racing/common.js
@@ -47,6 +47,7 @@ import { getTorrentsToPause } from "./preRace.js";
 export const raceExisting = async (api, settings, infohash) => {
     const logger = getLoggerV3();
     logger.debug(`raceExisting called with infohash: ${infohash}`);
+    const torrent = await api.getTorrent(infohash);
     // Try and pause existing torrents
     const torrents = await (async () => {
         try {
@@ -68,8 +69,6 @@ export const raceExisting = async (api, settings, infohash) => {
         process.exit(-1);
     }
     // TODO: Add trackers as tags?
-    const torrent = await api.getTorrent(infohash);
-    console.log(torrent);
     const announceOk = await reannounce(api, settings, torrent);
     if (announceOk === false) {
         logger.debug(`Going to resume torrents since failed to race`);

--- a/build/src/racing/common.js
+++ b/build/src/racing/common.js
@@ -31,6 +31,8 @@
  * [Fail to reannounce]
  * 3b. noop
  */
+import { sendMessageV2 } from "../discord/api.js";
+import { buildRacingBody } from "../discord/messages.js";
 import { sleep } from "../helpers/utilities.js";
 import { TrackerStatus } from "../interfaces.js";
 import { getLoggerV3 } from "../utils/logger.js";
@@ -69,14 +71,28 @@ export const raceExisting = async (api, settings, infohash) => {
         process.exit(-1);
     }
     const trackerNames = await addTrackersAsTags(api, settings, infohash);
-    const announceOk = await reannounce(api, settings, torrent);
-    if (announceOk === false) {
+    const announceSummary = await reannounce(api, settings, torrent);
+    if (announceSummary.ok === false) {
         logger.debug(`Going to resume torrents since failed to race`);
         await api.resumeTorrents(torrentsToPause);
         process.exit(0);
     }
     logger.info(`Successfully racing ${torrent.name}`);
-    // TODO: Discord message
+    if (settings.DISCORD_NOTIFICATIONS.enabled === true) {
+        const torrentAddedMessage = buildRacingBody(settings.DISCORD_NOTIFICATIONS, {
+            name: torrent.name,
+            size: torrent.size,
+            trackers: trackerNames,
+            reannounceCount: announceSummary.count
+        });
+        try {
+            await sendMessageV2(settings.DISCORD_NOTIFICATIONS.webhook, torrentAddedMessage);
+        }
+        catch (e) {
+            logger.error(`Failed to send message to discord: ${e}`);
+            // Do not throw for this failure.
+        }
+    }
     process.exit(0);
 };
 export const reannounce = async (api, settings, torrent) => {
@@ -97,11 +113,17 @@ export const reannounce = async (api, settings, torrent) => {
         }
         else {
             logger.debug(`Tracker is OK!`);
-            return true;
+            return {
+                ok: true,
+                count: attempts
+            };
         }
     }
     logger.debug(`Did not get OK from tracker even after ${settings.REANNOUNCE_LIMIT} re-announces!`);
-    return false;
+    return {
+        ok: false,
+        count: attempts
+    };
 };
 export const addTrackersAsTags = async (api, settings, infohash) => {
     const trackerNames = [];

--- a/build/src/racing/common.js
+++ b/build/src/racing/common.js
@@ -1,123 +1,106 @@
 /**
  * Racing a torrent consists of a few steps:
- * 
+ *
  * # Case 1: qbit-race used to add a new torrent
- * 
+ *
  * [Pre addition]
- * 
+ *
  * 1. Get list of existing torrents
  * 2. Check concurrent racing rules to see if it is ok to add
  *    a. Skip race if existing torrents
  * 3. Pause torrents before adding
  * 4. Add torrent
- * 
+ *
  * [Post addition]
  * 5. Try and reannounce if applicable
- * 
+ *
  * [Successfully announce]
  * 6a. Discord message
- * 
+ *
  * [Fail to reannounce]
  * 6b. Delete torrent, resume existing torrents
- * 
+ *
  * # Case 2: qbit-race used to apply "race mode" to existing torrent
- * 
+ *
  * 1. Try and pause torrents
  * 2. Try and reannounce if applicable
- * 
+ *
  * [Successfully announce]
  * 3a. Discord message
- * 
+ *
  * [Fail to reannounce]
  * 3b. noop
  */
-
 import { sleep } from "../helpers/utilities.js";
 import { TrackerStatus } from "../interfaces.js";
-import { QbittorrentApi, QbittorrentTorrent } from "../qbittorrent/api.js";
-import { Settings } from "../utils/config.js";
-import { getLoggerV3 } from "../utils/logger.js"
+import { getLoggerV3 } from "../utils/logger.js";
 import { getTorrentsToPause } from "./preRace.js";
-
-
 /**
  * raceExisting will try and "race" and existing torrent, by:
- * 
+ *
  * * Pausing existing torrents
  * * Try and reannounce if applicable
  * @param api The qbittorrent API
  * @param settings Settings for checking pause ratio etc.
  * @param infohash Infohash of newly added torrent
  */
-export const raceExisting = async (api: QbittorrentApi, settings: Settings, infohash: string) => {
-
+export const raceExisting = async (api, settings, infohash) => {
     const logger = getLoggerV3();
     logger.debug(`raceExisting called with infohash: ${infohash}`);
-
     // Try and pause existing torrents
     const torrents = await (async () => {
         try {
             const xd = await api.getTorrents();
             return xd;
-        } catch (e){
+        }
+        catch (e) {
             logger.error(`Failed to get torrents from qBittorrent API: ${e}`);
             process.exit(-1);
         }
     })();
-
     const torrentsToPause = getTorrentsToPause(settings, torrents);
     logger.debug(`Going to pause ${torrentsToPause.length} torrents`);
-
     try {
         await api.pauseTorrents(torrentsToPause);
-    } catch (e){
+    }
+    catch (e) {
         logger.error(`Failed to pause torrents: ${e}`);
         process.exit(-1);
     }
-
     // TODO: Add trackers as tags?
-
     const torrent = await api.getTorrent(infohash);
     const announceOk = await reannounce(api, settings, torrent);
-
-    if (announceOk === false){
+    if (announceOk === false) {
         logger.debug(`Going to resume torrents since failed to race`);
         await api.resumeTorrents(torrentsToPause);
         process.exit(0);
     }
-
     logger.info(`Successfully racing ${torrent.name}`);
-
     // TODO: Discord message
-
     process.exit(0);
-}
-
-export const reannounce = async (api: QbittorrentApi, settings: Settings, torrent: QbittorrentTorrent): Promise<boolean> => {
+};
+export const reannounce = async (api, settings, torrent) => {
     const logger = getLoggerV3();
     logger.debug(`Starting reannounce check`);
-
     let attempts = 0;
-
-    while (attempts < settings.REANNOUNCE_LIMIT){
-        logger.debug(`Reannounce attempt #${attempts+1}`);
-
+    while (attempts < settings.REANNOUNCE_LIMIT) {
+        logger.debug(`Reannounce attempt #${attempts + 1}`);
         const trackers = await api.getTrackers(torrent.hash);
         trackers.splice(0, 3); // Get rid of DHT, PEX etc.
         const working = trackers.some(tracker => tracker.status === TrackerStatus.WORKING);
-
         // Need to reannounce
-        if (working === false){
-            logger.debug(`No working tracker. Will reannounce and sleep...`)
+        if (working === false) {
+            logger.debug(`No working tracker. Will reannounce and sleep...`);
             await api.reannounce(torrent.hash);
             await sleep(settings.REANNOUNCE_INTERVAL);
             attempts++;
-        } else {
-            logger.debug(`Tracker is OK!`)
+        }
+        else {
+            logger.debug(`Tracker is OK!`);
             return true;
         }
     }
-
     logger.debug(`Did not get OK from tracker even after ${settings.REANNOUNCE_LIMIT} re-announces!`);
     return false;
-}
+};
+//# sourceMappingURL=common.js.map

--- a/build/src/racing/preRace.js
+++ b/build/src/racing/preRace.js
@@ -46,7 +46,6 @@ export const getTorrentsToPause = (settings, torrents) => {
         logger.debug(`Pause ratio is -1, wont pause any torrents`);
         return [];
     }
-    console.log(settings);
     const torrentsToPause = torrents.filter(torrent => {
         // Not seeding - no need to pause
         if (SEEDING_STATES.some(state => state === torrent.state) === false) {

--- a/build/src/racing/preRace.js
+++ b/build/src/racing/preRace.js
@@ -46,6 +46,7 @@ export const getTorrentsToPause = (settings, torrents) => {
         logger.debug(`Pause ratio is -1, wont pause any torrents`);
         return [];
     }
+    console.log(settings);
     const torrentsToPause = torrents.filter(torrent => {
         // Not seeding - no need to pause
         if (SEEDING_STATES.some(state => state === torrent.state) === false) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qbit-race",
-  "version": "2.0.0-alpha.9",
+  "version": "2.0.0-alpha.10",
   "description": "Qbit utilities for racing",
   "main": "./bin/index.js",
   "type": "module",

--- a/src/discord/messages.ts
+++ b/src/discord/messages.ts
@@ -75,6 +75,40 @@ export const buildTorrentAddedBody = (discordSettings: DISCORD_SETTINGS, torrent
     return buildMessageBody(discordSettings, partialBody);
 }
 
+// TODO: generalize with above
+export const buildRacingBody = (discordSettings: DISCORD_SETTINGS, torrentAddedInfo: TorrentAddedInfo): MessageBody => {
+    const humanSize = humanFileSize(torrentAddedInfo.size, false, 2);
+
+    let partialBody: PartialMesssageBody =  {
+        content: `Added ${torrentAddedInfo.name} (${humanSize})`,
+        embeds: [
+            {
+                title: torrentAddedInfo.name,
+                description: 'Racing in qBittorrent',
+                thumbnail: {
+                    url: discordSettings.botAvatar,
+                },
+                fields: [
+                    {
+                        name: torrentAddedInfo.trackers.length === 1 ? 'Tracker' : 'Trackers',
+                        value: torrentAddedInfo.trackers.join('\n')
+                    },
+                    {
+                        name: 'Size',
+                        value: humanSize
+                    },
+                    {
+                        name: 'Reannounce Count',
+                        value: torrentAddedInfo.reannounceCount.toString()
+                    }
+                ]
+            }
+        ]
+    }
+
+    return buildMessageBody(discordSettings, partialBody);
+}
+
 export const buildTorrentCompletedBody = (discordSettings: DISCORD_SETTINGS, torrent: QbittorrentTorrent): MessageBody => {
     const humanSize = humanFileSize(torrent.size, false, 2);
 

--- a/src/qbittorrent/api.ts
+++ b/src/qbittorrent/api.ts
@@ -3,6 +3,7 @@ import FormData from 'form-data';
 
 import { torrentFromApi, TorrentState, TransferInfo } from '../interfaces.js';
 import { QBITTORRENT_SETTINGS, Settings } from '../utils/config.js';
+import { getLoggerV3 } from '../utils/logger.js';
 
 
 export class QbittorrentApi {
@@ -36,18 +37,26 @@ export class QbittorrentApi {
 
     // Just wraps getTorrents as a convenience method for single torrent
     async getTorrent(infohash: string): Promise<QbittorrentTorrent> {
-        const torrents = await this.getTorrents([infohash]);
-        return torrents[0];
+        try {
+            const torrents = await this.getTorrents([infohash]);
+            return torrents[0];
+        } catch (e){
+            throw new Error(`Failed to get torrents from qBittorrent API. Error: ${e}`);
+        }        
     }
 
     async getTrackers(infohash: string): Promise<QbittorrentTracker[]> {
-        const response = await this.client.get(ApiEndpoints.torrentTrackers, {
-            params: {
-                hash: infohash,
-            }
-        });
-
-        return response.data;
+        try {
+            const response = await this.client.get(ApiEndpoints.torrentTrackers, {
+                params: {
+                    hash: infohash,
+                }
+            });
+    
+            return response.data;
+        } catch (e){
+            throw new Error(`Failed to get trackers from qBittorrent API for ${infohash}. Error: ${e}`);
+        }        
     }
 
     async addTags(torrents: ApiCompatibleTorrent[], tags: string[]){
@@ -80,11 +89,16 @@ export class QbittorrentApi {
     }
 
     async resumeTorrents(torrents: QbittorrentTorrent[]){
-        await this.client.get(ApiEndpoints.resumeTorrents, {
-            params: {
-                hashes: torrents.map(torrent => torrent.hash).join('|'),
-            }
-        });
+        try {
+            await this.client.get(ApiEndpoints.resumeTorrents, {
+                params: {
+                    hashes: torrents.map(torrent => torrent.hash).join('|'),
+                }
+            });
+        } catch (e){
+            throw new Error(`Failed to resume torrents. Error: ${e}`);
+        }
+        
     }
     
     async pauseTorrents(torrents: QbittorrentTorrent[]){

--- a/src/qbittorrent/api.ts
+++ b/src/qbittorrent/api.ts
@@ -39,6 +39,7 @@ export class QbittorrentApi {
     async getTorrent(infohash: string): Promise<QbittorrentTorrent> {
         try {
             const torrents = await this.getTorrents([infohash]);
+            console.log(torrents);
             return torrents[0];
         } catch (e){
             throw new Error(`Failed to get torrents from qBittorrent API. Error: ${e}`);
@@ -106,9 +107,11 @@ export class QbittorrentApi {
             return;
         }
 
-        await this.client.get(ApiEndpoints.pauseTorrents, {
-            params: {
-                hashes: torrents.map(torrent => torrent.hash).join('|')
+        const payload = `hashes=${torrents.map(torrent => torrent.hash).join('|')}`
+
+        await this.client.post(ApiEndpoints.pauseTorrents, payload, {
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
             }
         });
     }

--- a/src/qbittorrent/api.ts
+++ b/src/qbittorrent/api.ts
@@ -76,11 +76,16 @@ export class QbittorrentApi {
         const infohashes = torrents.map(torrent => torrent.hash);
         const payload = `hashes=${infohashes.join('|')}&tags=${tags.join(',')}`;
 
-        await this.client.post(ApiEndpoints.addTags, payload, {
-            headers: {
-                'Content-Type': 'application/x-www-form-urlencoded',
-            }
-        });
+        try {
+            await this.client.post(ApiEndpoints.addTags, payload, {
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                }
+            });
+        } catch (e){
+            throw new Error(`Failed to add tags to torrent: ${e}`);
+        }
+        
     }
 
     async setCategory(infohash: string, category: string){

--- a/src/qbittorrent/api.ts
+++ b/src/qbittorrent/api.ts
@@ -28,22 +28,26 @@ export class QbittorrentApi {
             params.hashes = hashes.join('|')
         }
 
-        const response = await this.client.get(ApiEndpoints.torrentsInfo, {
-            params: params,
-        });
-
-        return response.data;
+        try {
+            const response = await this.client.get(ApiEndpoints.torrentsInfo, {
+                params: params,
+            });
+    
+            return response.data;
+        } catch (e){
+            throw new Error(`Failed to get torrents from qBittorrent API. Error: ${e}`);
+        }        
     }
 
     // Just wraps getTorrents as a convenience method for single torrent
     async getTorrent(infohash: string): Promise<QbittorrentTorrent> {
-        try {
-            const torrents = await this.getTorrents([infohash]);
-            console.log(torrents);
-            return torrents[0];
-        } catch (e){
-            throw new Error(`Failed to get torrents from qBittorrent API. Error: ${e}`);
-        }        
+        const torrents = await this.getTorrents([infohash]);
+
+        if (torrents.length === 0){
+            throw new Error(`Torrent not found! (Infohash = ${infohash})`);
+        }
+        
+        return torrents[0];
     }
 
     async getTrackers(infohash: string): Promise<QbittorrentTracker[]> {

--- a/src/qbittorrent/api.ts
+++ b/src/qbittorrent/api.ts
@@ -156,11 +156,17 @@ export class QbittorrentApi {
     }
 
     async reannounce(infohash: string){
-        await this.client.get(ApiEndpoints.reannounce, {
-            params: {
-                hashes: infohash,
-            }
-        });
+        const payload = `hashes=${infohash}`;
+        
+        try {
+            await this.client.post(ApiEndpoints.reannounce, payload, {
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                }
+            });
+        } catch (e){
+            throw new Error(`Failed to reannounce! Error: ${e}`);
+        }
     }
 
     async getTransferInfo(): Promise<TransferInfo>{

--- a/src/racing/add.ts
+++ b/src/racing/add.ts
@@ -54,6 +54,7 @@ export const addTorrentToRace = async (api: QbittorrentApi, settings: Settings, 
         process.exit(0);
     }
 
+    // TODO: Move to common race part
     const torrentsToPause = getTorrentsToPause(settings, torrents);
 
     try {

--- a/src/racing/common.ts
+++ b/src/racing/common.ts
@@ -78,6 +78,7 @@ export const raceExisting = async (api: QbittorrentApi, settings: Settings, info
     // TODO: Add trackers as tags?
 
     const torrent = await api.getTorrent(infohash);
+    console.log(torrent);
     const announceOk = await reannounce(api, settings, torrent);
 
     if (announceOk === false){

--- a/src/racing/common.ts
+++ b/src/racing/common.ts
@@ -50,9 +50,10 @@ import { getTorrentsToPause } from "./preRace.js";
  * @param infohash Infohash of newly added torrent
  */
 export const raceExisting = async (api: QbittorrentApi, settings: Settings, infohash: string) => {
-
     const logger = getLoggerV3();
     logger.debug(`raceExisting called with infohash: ${infohash}`);
+
+    const torrent = await api.getTorrent(infohash);
 
     // Try and pause existing torrents
     const torrents = await (async () => {
@@ -76,9 +77,6 @@ export const raceExisting = async (api: QbittorrentApi, settings: Settings, info
     }
 
     // TODO: Add trackers as tags?
-
-    const torrent = await api.getTorrent(infohash);
-    console.log(torrent);
     const announceOk = await reannounce(api, settings, torrent);
 
     if (announceOk === false){

--- a/src/racing/common.ts
+++ b/src/racing/common.ts
@@ -1,0 +1,50 @@
+/**
+ * Racing a torrent consists of a few steps:
+ * 
+ * # Case 1: qbit-race used to add a new torrent
+ * 
+ * [Pre addition]
+ * 
+ * 1. Get list of existing torrents
+ * 2. Check concurrent racing rules to see if it is ok to add
+ *    a. Skip race if existing torrents
+ * 3. Pause torrents before adding
+ * 4. Add torrent
+ * 
+ * [Post addition]
+ * 5. Try and reannounce if applicable
+ * 
+ * [Successfully announce]
+ * 6a. Discord message
+ * 
+ * [Fail to reannounce]
+ * 6b. Delete torrent, resume existing torrents
+ * 
+ * # Case 2: qbit-race used to apply "race mode" to existing torrent
+ * 
+ * 1. Try and pause torrents
+ * 2. Try and reannounce if applicable
+ * 
+ * [Successfully announce]
+ * 3a. Discord message
+ * 
+ * [Fail to reannounce]
+ * 3b. noop
+ */
+
+import { QbittorrentApi } from "../qbittorrent/api.js";
+import { Settings } from "../utils/config.js";
+
+
+/**
+ * raceExisting will try and "race" and existing torrent, by:
+ * 
+ * * Pausing existing torrents
+ * * Try and reannounce if applicable
+ * @param api The qbittorrent API
+ * @param settings Settings for checking pause ratio etc.
+ * @param infohash Infohash of newly added torrent
+ */
+export const raceExisting = async (api: QbittorrentApi, settings: Settings, infohash: string) => {
+
+}


### PR DESCRIPTION
Allows qbit-race to be called via:

```
qbit-race race -i [infohash]
```

In order to:

* Pause existing torrents for good racing performance
* Reannounce if needed
* Add trackers as tags
* Send discord message

It does not:
* Delete torrent if fail to race
* Skip torrent if existing races

Fixes #37 