### PR TITLE
Feature/no tracker tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,12 @@ You can view the logs under `~/.config/qbit-race/logs.txt` to try and debug.
 
 These are additional parameters you can specify in autoDL for additional functionality
 
+### No Tracker Tags
+
+By default, when adding the torrent, `qbit-race` also "tags" the torrent with the hostname of all trackers. This is mostly useful in older version of qBittorrent to be able to sort torrents by trackers.
+
+To disable this, you can pass an extra flag `--no-tracker-tags` to the `qibt-race add` command.
+
 ### Torrent Category
 
 In the autoDL arguments field, you may specify a category (per filter, or global) by adding to the end of arguments `--category "the category name"`

--- a/bin/index.mjs
+++ b/bin/index.mjs
@@ -59,10 +59,13 @@ program.command('completed').description('Run post race procedure on complete of
     await postRaceResumeV2(api, config, options.infohash);
 })
 
-program.command('add').description('Add a new torrent').requiredOption('-p, --path <path>', 'The path to the .torrent file. Must be a single file, not a directory!').option('-c, --category <category>', 'Category to set in qBittorrent').action(async(options) => {
+program.command('add').description('Add a new torrent').requiredOption('-p, --path <path>', 'The path to the .torrent file. Must be a single file, not a directory!').option('-c, --category <category>', 'Category to set in qBittorrent').option('--no-tracker-tags', 'Disable auto adding the trackers as tags on the torrent in qBittorrent').action(async(options) => {
     logger.debug(`Going to add torrent from ${options.path}, and set category ${options.category}`);
     const api = await loginV2(config.QBITTORRENT_SETTINGS);
-    await addTorrentToRace(api, config, options.path, options.category);
+
+    await addTorrentToRace(api, config, options.path, {
+        trackerTags: options.trackerTags, // commander is extra smart, if we define with --no , it will default boolean to true and remove `no` from the name...
+    }, options.category);
 })
 
 program.command('race').description('Race an existing torrent').requiredOption('-i, --infohash <infohash>', 'The infohash of the torrent already in qBittorrent. Not case sensitive').action(async(options) => {

--- a/build/src/racing/add.js
+++ b/build/src/racing/add.js
@@ -9,7 +9,7 @@ import { sleep } from "../helpers/utilities.js";
 import { TrackerStatus } from "../interfaces.js";
 import { buildTorrentAddedBody } from "../discord/messages.js";
 import { sendMessageV2 } from "../discord/api.js";
-export const addTorrentToRace = async (api, settings, path, category) => {
+export const addTorrentToRace = async (api, settings, path, options, category) => {
     const logger = getLoggerV3();
     logger.debug(`Called with path: ${path}, category: ${category}`);
     // Read the torrent file and get info
@@ -74,12 +74,19 @@ export const addTorrentToRace = async (api, settings, path, category) => {
         logger.error(`Failed to get tags for torrent: ${e}`);
         process.exit(1);
     }
-    try {
-        await api.addTags([torrentMetainfo], trackersAsTags);
+    // TODO: Also handle CLI flag to add extra tags
+    // See: https://github.com/ckcr4lyf/qbit-race/issues/40
+    if (options.trackerTags === false) {
+        logger.debug(`--no-tracker-tags specified, will skip adding tags to the torrent!`);
     }
-    catch (e) {
-        logger.error(`Failed to add tags to torrent: ${e}`);
-        process.exit(1);
+    else {
+        try {
+            await api.addTags([torrentMetainfo], trackersAsTags);
+        }
+        catch (e) {
+            logger.error(`Failed to add tags to torrent: ${e}`);
+            process.exit(1);
+        }
     }
     let torrent;
     try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qbit-race",
-  "version": "2.0.0-alpha.9",
+  "version": "2.0.0-alpha.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "qbit-race",
-      "version": "2.0.0-alpha.9",
+      "version": "2.0.0-alpha.10",
       "license": "ISC",
       "dependencies": {
         "@ckcr4lyf/bencode-esm": "^0.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qbit-race",
-  "version": "2.0.0-alpha.10",
+  "version": "2.0.0-alpha.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "qbit-race",
-      "version": "2.0.0-alpha.10",
+      "version": "2.0.0-alpha.11",
       "license": "ISC",
       "dependencies": {
         "@ckcr4lyf/bencode-esm": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qbit-race",
-  "version": "2.0.0-alpha.10",
+  "version": "2.0.0-alpha.11",
   "description": "Qbit utilities for racing",
   "main": "./bin/index.js",
   "type": "module",

--- a/src/racing/add.ts
+++ b/src/racing/add.ts
@@ -5,7 +5,7 @@
 import { getTorrentMetainfo, torrentMetainfo, TorrentMetainfoV2 } from "../helpers/torrent.js";
 import { getLoggerV3 } from "../utils/logger.js"
 import * as fs from 'fs';
-import { Settings } from "../utils/config";
+import { Options, Settings } from "../utils/config";
 import { QbittorrentApi, QbittorrentTorrent } from "../qbittorrent/api";
 import { concurrentRacesCheck, getTorrentsToPause } from "./preRace.js";
 import { sleep } from "../helpers/utilities.js";
@@ -13,7 +13,7 @@ import { TrackerStatus } from "../interfaces.js";
 import { buildTorrentAddedBody } from "../discord/messages.js";
 import { sendMessageV2 } from "../discord/api.js";
 
-export const addTorrentToRace = async (api: QbittorrentApi, settings: Settings, path: string, category?: string) => {
+export const addTorrentToRace = async (api: QbittorrentApi, settings: Settings, path: string, options: Options, category?: string) => {
 
     const logger = getLoggerV3();
     logger.debug(`Called with path: ${path}, category: ${category}`);
@@ -88,11 +88,17 @@ export const addTorrentToRace = async (api: QbittorrentApi, settings: Settings, 
         process.exit(1);
     }
 
-    try {
-        await api.addTags([torrentMetainfo], trackersAsTags);
-    } catch (e){
-        logger.error(`Failed to add tags to torrent: ${e}`);
-        process.exit(1);
+    // TODO: Also handle CLI flag to add extra tags
+    // See: https://github.com/ckcr4lyf/qbit-race/issues/40
+    if (options.trackerTags === false){
+        logger.debug(`--no-tracker-tags specified, will skip adding tags to the torrent!`);
+    } else {
+        try {
+            await api.addTags([torrentMetainfo], trackersAsTags);
+        } catch (e){
+            logger.error(`Failed to add tags to torrent: ${e}`);
+            process.exit(1);
+        }
     }
 
     let torrent: QbittorrentTorrent;

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -97,6 +97,16 @@ export type Settings = {
     CATEGORY_FINISH_CHANGE: Record<string, string>;
 }
 
+/**
+ * Extra options to be passed via CLI args
+ */
+export type Options = {
+    /**
+     * Whether the trackers should be added as tags to the torrent
+     */
+    trackerTags: boolean;
+}
+
 export const defaultSettings: Settings = {
     REANNOUNCE_INTERVAL: 5000,
     REANNOUNCE_LIMIT: 30,


### PR DESCRIPTION
Adds an option `--no-tracker-tags` , which will disable the auto tracker hostname tags when using `qbit-race add`