### PR TITLE
Support no tracker tags and extra tags on race existing

### DIFF
--- a/bin/index.mjs
+++ b/bin/index.mjs
@@ -69,13 +69,16 @@ program.command('add').description('Add a new torrent').requiredOption('-p, --pa
     }, options.category);
 })
 
-program.command('race').description('Race an existing torrent').requiredOption('-i, --infohash <infohash>', 'The infohash of the torrent already in qBittorrent. Not case sensitive').action(async(options) => {
+program.command('race').description('Race an existing torrent').requiredOption('-i, --infohash <infohash>', 'The infohash of the torrent already in qBittorrent. Not case sensitive').option('--no-tracker-tags', 'Disable auto adding the trackers as tags on the torrent in qBittorrent').option('--extra-tags <tags>', 'Comma-separated list off extra tags to add. E.g. --extra-tags "linux,foss"').action(async(options) => {
     logger.debug(`Going to race ${options.infohash}`);
     logger.info(`Going to login`);
     const api = await loginV2(config.QBITTORRENT_SETTINGS);
 
     try {
-        await raceExisting(api, config, options.infohash);
+        await raceExisting(api, config, options.infohash, {
+            trackerTags: options.trackerTags, // commander is extra smart, if we define with --no , it will default boolean to true and remove `no` from the name...
+            extraTags: options.extraTags, // The raw csv string. We will split inside the function
+        });
     } catch (e){
         logger.error(`Failed to race ${options.infohash}. Error: ${e}. (${e.stack})`);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qbit-race",
-  "version": "2.0.0-alpha.11",
+  "version": "2.0.0-alpha.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "qbit-race",
-      "version": "2.0.0-alpha.11",
+      "version": "2.0.0-alpha.13",
       "license": "ISC",
       "dependencies": {
         "@ckcr4lyf/bencode-esm": "^0.0.2",

--- a/src/racing/common.ts
+++ b/src/racing/common.ts
@@ -78,10 +78,11 @@ export const raceExisting = async (api: QbittorrentApi, settings: Settings, info
         process.exit(-1);
     }
 
+    let trackersAsTags: string[] = [];
     if (options.trackerTags === false){
         logger.debug(`--no-tracker-tags specified, will skip adding them to the torrent!`);
     } else {
-        const trackerNames = await addTrackersAsTags(api, settings, infohash);
+        trackersAsTags = await addTrackersAsTags(api, settings, infohash);
     }
 
     if (options.extraTags !== undefined){
@@ -104,7 +105,7 @@ export const raceExisting = async (api: QbittorrentApi, settings: Settings, info
         const torrentAddedMessage = buildRacingBody(settings.DISCORD_NOTIFICATIONS, {
             name: torrent.name,
             size: torrent.size,
-            trackers: trackerNames,
+            trackers: trackersAsTags,
             reannounceCount: announceSummary.count
         });
 

--- a/src/racing/common.ts
+++ b/src/racing/common.ts
@@ -37,7 +37,7 @@ import { buildRacingBody } from "../discord/messages.js";
 import { sleep } from "../helpers/utilities.js";
 import { TrackerStatus } from "../interfaces.js";
 import { QbittorrentApi, QbittorrentTorrent } from "../qbittorrent/api.js";
-import { Settings } from "../utils/config.js";
+import { Options, Settings } from "../utils/config.js";
 import { getLoggerV3 } from "../utils/logger.js"
 import { getTorrentsToPause } from "./preRace.js";
 
@@ -51,7 +51,7 @@ import { getTorrentsToPause } from "./preRace.js";
  * @param settings Settings for checking pause ratio etc.
  * @param infohash Infohash of newly added torrent
  */
-export const raceExisting = async (api: QbittorrentApi, settings: Settings, infohash: string) => {
+export const raceExisting = async (api: QbittorrentApi, settings: Settings, infohash: string, options: Options) => {
     const logger = getLoggerV3();
     logger.debug(`raceExisting called with infohash: ${infohash}`);
 
@@ -78,7 +78,18 @@ export const raceExisting = async (api: QbittorrentApi, settings: Settings, info
         process.exit(-1);
     }
 
-    const trackerNames = await addTrackersAsTags(api, settings, infohash);
+    if (options.trackerTags === false){
+        logger.debug(`--no-tracker-tags specified, will skip adding them to the torrent!`);
+    } else {
+        const trackerNames = await addTrackersAsTags(api, settings, infohash);
+    }
+
+    if (options.extraTags !== undefined){
+        const extraTags = options.extraTags.split(',');
+        logger.debug(`Adding extra tags: ${extraTags}`);
+        await api.addTags([{ hash: infohash }], extraTags);
+    }
+    
     const announceSummary = await reannounce(api, settings, torrent);
 
     if (announceSummary.ok === false){


### PR DESCRIPTION
The flags `--no-tracker-tags` and `--extra-tags` were only supported with `qbit-race add` and not with `qbit-race race`. This PR adds this feature to `qbit-race race` with the same syntax. I didn't add support for setting the category because it doesn't really make sense to change the category after the torrent has already started.